### PR TITLE
Improve discovery error recovery and motion accessibility

### DIFF
--- a/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.css
+++ b/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.css
@@ -41,6 +41,54 @@
     font-style: italic;
 }
 
+.seerrfin-retry-state {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.8em;
+    padding-top: 1em;
+    padding-bottom: 1em;
+    font-style: normal;
+}
+
+.seerrfin-retry-message {
+    max-width: 42em;
+}
+
+.seerrfin-retry-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4em;
+    min-height: 2.4em;
+    margin: 0;
+    padding: 0.55em 0.95em;
+    border-radius: 999px;
+    cursor: pointer;
+    white-space: nowrap;
+    box-shadow: 0 0.2em 0.75em rgba(0, 0, 0, 0.22);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.seerrfin-retry-button:hover:not(:disabled),
+.seerrfin-retry-button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 0.35em 1em rgba(0, 0, 0, 0.3);
+}
+
+.seerrfin-retry-button:active:not(:disabled) {
+    transform: translateY(0);
+}
+
+.seerrfin-retry-button:disabled {
+    cursor: wait;
+    opacity: 0.7;
+}
+
+.seerrfin-retry-button .material-icons {
+    font-size: 1.15em;
+}
+
 .seerrfin-loading-row {
     padding: 1em 1.5em;
     color: var(--secondaryTextColor);
@@ -114,6 +162,10 @@
     .seerrfin-skeleton-card::after,
     .seerrfin-section-fadein {
         animation: none;
+    }
+
+    .seerrfin-retry-button {
+        transition: none;
     }
 }
 

--- a/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.css
+++ b/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.css
@@ -109,6 +109,14 @@
     animation: seerrfin-fadein 0.2s ease-out;
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .seerrfin-skeleton-title::after,
+    .seerrfin-skeleton-card::after,
+    .seerrfin-section-fadein {
+        animation: none;
+    }
+}
+
 .seerrfin-poster-section .sectionTitleContainer-cards {
     display: flex;
     align-items: baseline;

--- a/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.js
+++ b/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.js
@@ -1913,13 +1913,8 @@ if (typeof window.seerrFinPlugin === 'undefined') {
             const self = this;
 
             document.addEventListener('click', function (e) {
-                const button = e.target.closest('[data-seerrfin-retry="discovery"]');
+                const button = e.target.closest('[data-seerrfin-retry]');
                 if (!button) {
-                    return;
-                }
-
-                const container = button.closest('.seerrfin-movies-sections, .seerrfin-tv-sections');
-                if (!container) {
                     return;
                 }
 
@@ -1932,10 +1927,26 @@ if (typeof window.seerrFinPlugin === 'undefined') {
                     label.textContent = 'Retrying…';
                 }
 
-                container.dataset.seerrfinLoading = 'false';
-                delete container.dataset.seerrfinLoaded;
-                const type = container.classList.contains('seerrfin-movies-sections') ? 'movies' : 'tv';
-                self.loadTab(type, container);
+                const retryTarget = button.getAttribute('data-seerrfin-retry');
+                if (retryTarget === 'discovery') {
+                    const container = button.closest('.seerrfin-movies-sections, .seerrfin-tv-sections');
+                    if (!container) {
+                        return;
+                    }
+
+                    container.dataset.seerrfinLoading = 'false';
+                    delete container.dataset.seerrfinLoaded;
+                    const type = container.classList.contains('seerrfin-movies-sections') ? 'movies' : 'tv';
+                    self.loadTab(type, container);
+                    return;
+                }
+
+                if (retryTarget === 'grid') {
+                    const gridView = button.closest('[data-seerrfin-grid-view]');
+                    if (gridView) {
+                        self.loadMoreGridItems(gridView, true);
+                    }
+                }
             }, true);
         },
 
@@ -2164,6 +2175,10 @@ if (typeof window.seerrFinPlugin === 'undefined') {
 
             gridView.dataset.loading = 'true';
             if (isInitial) {
+                const retryState = itemsContainer.querySelector('.seerrfin-retry-state');
+                if (retryState) {
+                    retryState.remove();
+                }
                 status.textContent = 'Loading...';
                 status.style.display = '';
             } else {
@@ -2240,7 +2255,7 @@ if (typeof window.seerrFinPlugin === 'undefined') {
                 loadMoreBtn.disabled = false;
                 console.error('SeerrFin grid load failed:', err);
                 if (loadedCount === 0) {
-                    itemsContainer.innerHTML = `<div class="seerrfin-empty-row">Failed to load items.</div>`;
+                    itemsContainer.innerHTML = self.renderRetryState('Failed to load items.', 'grid');
                 }
                 if (useNativeCards) {
                     window.seerrFinNativeUi.updateGridChrome(gridView);

--- a/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.js
+++ b/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.js
@@ -34,6 +34,7 @@ if (typeof window.seerrFinPlugin === 'undefined') {
                 this.bindRequestHandler();
                 this.bindCardClickHandler();
                 this.bindViewMoreHandler();
+                this.bindRetryHandler();
                 this.loadDisplaySettings();
                 this.setupSearchIntegration();
             }
@@ -207,6 +208,17 @@ if (typeof window.seerrFinPlugin === 'undefined') {
             });
         },
 
+        renderRetryState: function (message, retryTarget) {
+            return `
+                <div class="seerrfin-empty-row seerrfin-retry-state" role="alert">
+                    <span class="seerrfin-retry-message">${this.escapeHtml(message)}</span>
+                    <button type="button" class="seerrfin-retry-button raised emby-button" data-seerrfin-retry="${this.escapeHtml(retryTarget)}">
+                        <span class="material-icons notranslate" aria-hidden="true">refresh</span>
+                        <span data-seerrfin-retry-label>Try again</span>
+                    </button>
+                </div>`;
+        },
+
         renderIfContainerVisible: function (type) {
             const selector = type === 'movies' ? '.seerrfin-movies-sections' : '.seerrfin-tv-sections';
             const container = this.findActiveContainer(selector);
@@ -331,7 +343,10 @@ if (typeof window.seerrFinPlugin === 'undefined') {
                         return;
                     }
                     if (!anySuccess && !isStale()) {
-                        container.innerHTML = `<div class="seerrfin-empty-row">Failed to load discovery rows. Check Seerr settings and that your Jellyfin user is linked in Seerr.</div>`;
+                        container.innerHTML = self.renderRetryState(
+                            'Failed to load discovery rows. Check Seerr settings and that your Jellyfin user is linked in Seerr.',
+                            'discovery'
+                        );
                     }
                     finishLoading();
                 };
@@ -405,7 +420,10 @@ if (typeof window.seerrFinPlugin === 'undefined') {
                 console.error('SeerrFin:', err);
                 container.dataset.seerrfinLoading = 'false';
                 container.dataset.seerrfinLoaded = 'true';
-                container.innerHTML = `<div class="seerrfin-empty-row">Failed to load discovery rows. Check Seerr settings and that your Jellyfin user is linked in Seerr.</div>`;
+                container.innerHTML = self.renderRetryState(
+                    'Failed to load discovery rows. Check Seerr settings and that your Jellyfin user is linked in Seerr.',
+                    'discovery'
+                );
             });
         },
 
@@ -1888,6 +1906,36 @@ if (typeof window.seerrFinPlugin === 'undefined') {
                 if (browsePath && name) {
                     self.openGridView(boxContainer, name, browsePath);
                 }
+            }, true);
+        },
+
+        bindRetryHandler: function () {
+            const self = this;
+
+            document.addEventListener('click', function (e) {
+                const button = e.target.closest('[data-seerrfin-retry="discovery"]');
+                if (!button) {
+                    return;
+                }
+
+                const container = button.closest('.seerrfin-movies-sections, .seerrfin-tv-sections');
+                if (!container) {
+                    return;
+                }
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                button.disabled = true;
+                const label = button.querySelector('[data-seerrfin-retry-label]');
+                if (label) {
+                    label.textContent = 'Retrying…';
+                }
+
+                container.dataset.seerrfinLoading = 'false';
+                delete container.dataset.seerrfinLoaded;
+                const type = container.classList.contains('seerrfin-movies-sections') ? 'movies' : 'tv';
+                self.loadTab(type, container);
             }, true);
         },
 


### PR DESCRIPTION
## Summary

This improves discovery errors and motion accessibility across SeerrFin’s injected UI.

- Add a Jellyfin styled **Try again** button when discovery rows fail to load
- Add the same retry button for initial grid loading errors
- Show a **Retrying…** state while a new request starts
- Respect `prefers-reduced-motion` by disabling skeleton shimmer, section fade-in, and retry-button transitions
- Keep the existing stale-load and grid-session protections during retries

I didn't test against a configured Jellyfin and Seerr instance and would like for the author or another contributor to do it before merging the PR
