### PR TITLE
feat: support multiple Radarr and Sonarr instances

### DIFF
--- a/src/Jellyfin.Plugin.SeerrFin/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Configuration/PluginConfiguration.cs
@@ -19,6 +19,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string? SonarrApiKey { get; set; } = string.Empty;
 
+    public List<ServarrInstanceConfig> ServarrInstances { get; set; } = new();
+
     public string? JellyseerrPreferredLanguages { get; set; } = "en";
 
     public string? TmdbApiKey { get; set; } = string.Empty;

--- a/src/Jellyfin.Plugin.SeerrFin/Configuration/ServarrConfigHelper.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Configuration/ServarrConfigHelper.cs
@@ -1,0 +1,202 @@
+namespace Jellyfin.Plugin.SeerrFin.Configuration;
+
+public static class ServarrConfigHelper
+{
+    private static readonly string[] KnownKinds = new[] { "radarr", "sonarr" };
+
+    public static IReadOnlyList<ServarrInstanceConfig> Resolve(PluginConfiguration config)
+    {
+        config.ServarrInstances ??= new List<ServarrInstanceConfig>();
+
+        List<ServarrInstanceConfig> instances = config.ServarrInstances
+            .Where(instance => instance != null)
+            .Select(NormalizeInstance)
+            .Where(instance => !IsEffectivelyEmpty(instance))
+            .ToList();
+
+        if (instances.Count == 0)
+        {
+            instances = CreateLegacyInstances(config);
+        }
+
+        NormalizeNames(instances);
+        NormalizeDefaults(instances);
+
+        config.ServarrInstances = instances;
+        SyncLegacyFields(config, instances);
+        return instances;
+    }
+
+    public static IReadOnlyList<ServarrInstanceConfig> GetConfiguredInstances(PluginConfiguration config, string kind) =>
+        Resolve(config)
+            .Where(instance => string.Equals(instance.Kind, NormalizeKind(kind), StringComparison.OrdinalIgnoreCase) && IsConfigured(instance))
+            .ToList();
+
+    public static string? GetPreferredUrl(PluginConfiguration config, string kind)
+    {
+        ServarrInstanceConfig? instance = GetPreferredInstance(config, kind);
+        return instance?.Url?.Trim();
+    }
+
+    public static ServarrInstanceConfig? GetPreferredInstance(PluginConfiguration config, string kind)
+    {
+        string normalizedKind = NormalizeKind(kind);
+        IReadOnlyList<ServarrInstanceConfig> instances = Resolve(config)
+            .Where(instance => string.Equals(instance.Kind, normalizedKind, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (instances.Count == 0)
+        {
+            return null;
+        }
+
+        ServarrInstanceConfig? configuredDefault = instances.FirstOrDefault(instance => instance.IsDefault && IsConfigured(instance));
+        if (configuredDefault != null)
+        {
+            return configuredDefault;
+        }
+
+        ServarrInstanceConfig? configured = instances.FirstOrDefault(IsConfigured);
+        if (configured != null)
+        {
+            return configured;
+        }
+
+        return instances[0];
+    }
+
+    public static bool IsConfigured(ServarrInstanceConfig instance) =>
+        !string.IsNullOrWhiteSpace(instance.Url) && !string.IsNullOrWhiteSpace(instance.ApiKey);
+
+    public static string NormalizeKind(string? kind) =>
+        string.Equals(kind, "sonarr", StringComparison.OrdinalIgnoreCase) ? "sonarr" : "radarr";
+
+    public static string GetKindLabel(string kind) =>
+        string.Equals(NormalizeKind(kind), "sonarr", StringComparison.OrdinalIgnoreCase) ? "Sonarr" : "Radarr";
+
+    private static ServarrInstanceConfig NormalizeInstance(ServarrInstanceConfig instance)
+    {
+        string kind = NormalizeKind(instance.Kind);
+        return new ServarrInstanceConfig
+        {
+            Kind = kind,
+            Name = string.IsNullOrWhiteSpace(instance.Name) ? string.Empty : instance.Name.Trim(),
+            Url = string.IsNullOrWhiteSpace(instance.Url) ? string.Empty : instance.Url.Trim(),
+            ApiKey = string.IsNullOrWhiteSpace(instance.ApiKey) ? string.Empty : instance.ApiKey.Trim(),
+            IsDefault = instance.IsDefault,
+            Is4k = string.Equals(kind, "radarr", StringComparison.OrdinalIgnoreCase) && instance.Is4k
+        };
+    }
+
+    private static List<ServarrInstanceConfig> CreateLegacyInstances(PluginConfiguration config)
+    {
+        List<ServarrInstanceConfig> instances = new();
+
+        if (!string.IsNullOrWhiteSpace(config.RadarrUrl) || !string.IsNullOrWhiteSpace(config.RadarrApiKey))
+        {
+            instances.Add(new ServarrInstanceConfig
+            {
+                Kind = "radarr",
+                Name = string.Empty,
+                Url = config.RadarrUrl?.Trim() ?? string.Empty,
+                ApiKey = config.RadarrApiKey?.Trim() ?? string.Empty,
+                IsDefault = true,
+                Is4k = false
+            });
+        }
+
+        if (!string.IsNullOrWhiteSpace(config.SonarrUrl) || !string.IsNullOrWhiteSpace(config.SonarrApiKey))
+        {
+            instances.Add(new ServarrInstanceConfig
+            {
+                Kind = "sonarr",
+                Name = string.Empty,
+                Url = config.SonarrUrl?.Trim() ?? string.Empty,
+                ApiKey = config.SonarrApiKey?.Trim() ?? string.Empty,
+                IsDefault = true,
+                Is4k = false
+            });
+        }
+
+        return instances;
+    }
+
+    private static void NormalizeNames(List<ServarrInstanceConfig> instances)
+    {
+        Dictionary<string, int> counts = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (ServarrInstanceConfig instance in instances)
+        {
+            string kind = NormalizeKind(instance.Kind);
+            counts.TryGetValue(kind, out int current);
+            current++;
+            counts[kind] = current;
+
+            if (string.IsNullOrWhiteSpace(instance.Name))
+            {
+                instance.Name = $"{GetKindLabel(kind)} {current}";
+            }
+            else
+            {
+                instance.Name = instance.Name.Trim();
+            }
+        }
+    }
+
+    private static void NormalizeDefaults(List<ServarrInstanceConfig> instances)
+    {
+        foreach (string kind in KnownKinds)
+        {
+            List<ServarrInstanceConfig> byKind = instances
+                .Where(instance => string.Equals(instance.Kind, kind, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (byKind.Count == 0)
+            {
+                continue;
+            }
+
+            ServarrInstanceConfig? selected = byKind.FirstOrDefault(instance => instance.IsDefault && IsConfigured(instance))
+                ?? byKind.FirstOrDefault(instance => instance.IsDefault)
+                ?? byKind.FirstOrDefault(IsConfigured)
+                ?? byKind[0];
+
+            bool selectedSeen = false;
+            foreach (ServarrInstanceConfig instance in byKind)
+            {
+                if (!selectedSeen && ReferenceEquals(instance, selected))
+                {
+                    instance.IsDefault = true;
+                    selectedSeen = true;
+                }
+                else
+                {
+                    instance.IsDefault = false;
+                }
+            }
+        }
+    }
+
+    private static void SyncLegacyFields(PluginConfiguration config, IReadOnlyList<ServarrInstanceConfig> instances)
+    {
+        ServarrInstanceConfig? radarr = GetPreferredLegacySource(instances, "radarr");
+        ServarrInstanceConfig? sonarr = GetPreferredLegacySource(instances, "sonarr");
+
+        config.RadarrUrl = radarr?.Url?.Trim() ?? string.Empty;
+        config.RadarrApiKey = radarr?.ApiKey?.Trim() ?? string.Empty;
+        config.SonarrUrl = sonarr?.Url?.Trim() ?? string.Empty;
+        config.SonarrApiKey = sonarr?.ApiKey?.Trim() ?? string.Empty;
+    }
+
+    private static ServarrInstanceConfig? GetPreferredLegacySource(IReadOnlyList<ServarrInstanceConfig> instances, string kind)
+    {
+        string normalizedKind = NormalizeKind(kind);
+        return instances.FirstOrDefault(instance => string.Equals(instance.Kind, normalizedKind, StringComparison.OrdinalIgnoreCase) && instance.IsDefault && IsConfigured(instance))
+            ?? instances.FirstOrDefault(instance => string.Equals(instance.Kind, normalizedKind, StringComparison.OrdinalIgnoreCase) && IsConfigured(instance))
+            ?? instances.FirstOrDefault(instance => string.Equals(instance.Kind, normalizedKind, StringComparison.OrdinalIgnoreCase) && instance.IsDefault)
+            ?? instances.FirstOrDefault(instance => string.Equals(instance.Kind, normalizedKind, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsEffectivelyEmpty(ServarrInstanceConfig instance) =>
+        string.IsNullOrWhiteSpace(instance.Url) && string.IsNullOrWhiteSpace(instance.ApiKey);
+}

--- a/src/Jellyfin.Plugin.SeerrFin/Configuration/ServarrInstanceConfig.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Configuration/ServarrInstanceConfig.cs
@@ -1,0 +1,16 @@
+namespace Jellyfin.Plugin.SeerrFin.Configuration;
+
+public sealed class ServarrInstanceConfig
+{
+    public string Kind { get; set; } = "radarr";
+
+    public string? Name { get; set; } = string.Empty;
+
+    public string? Url { get; set; } = string.Empty;
+
+    public string? ApiKey { get; set; } = string.Empty;
+
+    public bool IsDefault { get; set; }
+
+    public bool Is4k { get; set; }
+}

--- a/src/Jellyfin.Plugin.SeerrFin/Configuration/config.html
+++ b/src/Jellyfin.Plugin.SeerrFin/Configuration/config.html
@@ -65,6 +65,66 @@
             padding: 1em;
         }
 
+        .bst-servarr-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1em;
+            margin-bottom: 1em;
+        }
+
+        .bst-servarr-instance-list {
+            display: flex;
+            flex-direction: column;
+            gap: 1em;
+        }
+
+        .bst-servarr-instance-card {
+            display: flex;
+            flex-direction: column;
+            gap: 1em;
+        }
+
+        .bst-servarr-instance-top {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 1em;
+        }
+
+        .bst-servarr-instance-title-wrap {
+            min-width: 0;
+        }
+
+        .bst-servarr-instance-kind {
+            font-size: 1.05em;
+            font-weight: 500;
+            line-height: 1.35;
+            color: #fff;
+            margin-bottom: 0.25em;
+        }
+
+        .bst-servarr-instance-actions {
+            display: flex;
+            align-items: center;
+            gap: 0.65em;
+            flex-shrink: 0;
+        }
+
+        .bst-modal--compact {
+            width: min(100%, 24em);
+        }
+
+        .bst-modal-actions--stack {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .bst-modal-btn--choice {
+            justify-content: center;
+            text-align: center;
+        }
+
         .bst-section-header {
             display: flex;
             justify-content: space-between;
@@ -955,46 +1015,11 @@
                 <div class="bst-section-container">
                     <div class="bst-section-title">Radarr/Sonarr configuration for download progress on Requests page</div>
                     <div class="bst-card">
-                        <div class="bst-input-row" style="margin-bottom: 1.25em;">
-                            <div class="bst-input-group">
-                                <div class="bst-field-main">
-                                    <label class="bst-label bst-label--side bst-label--required" for="radarrUrl">Radarr URL</label>
-                                    <div class="bst-input-stack">
-                                        <input id="radarrUrl" name="radarrUrl" type="text" class="bst-input" placeholder="http://192.168.1.170:7878" />
-                                        <div class="bst-field-desc">URL used by the server to reach Radarr (or you use to access it)</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="bst-input-group">
-                                <div class="bst-field-main">
-                                    <label class="bst-label bst-label--side bst-label--required" for="radarrApiKey">Radarr API Key</label>
-                                    <div class="bst-input-stack">
-                                        <input id="radarrApiKey" name="radarrApiKey" type="password" class="bst-input" autocomplete="off" />
-                                        <div class="bst-field-desc">Key for Radarr which you can get from Radarr → Settings → General → Security → API Key</div>
-                                    </div>
-                                </div>
-                            </div>
+                        <div class="bst-servarr-toolbar">
+                            <div class="bst-field-desc">Add one or more Radarr or Sonarr instances. The plugin uses them for Requests progress and open links.</div>
+                            <button type="button" class="bst-customize-btn" id="bstAddServarrInstance" aria-label="Add Servarr instance">+</button>
                         </div>
-                        <div class="bst-input-row">
-                            <div class="bst-input-group">
-                                <div class="bst-field-main">
-                                    <label class="bst-label bst-label--side bst-label--required" for="sonarrUrl">Sonarr URL</label>
-                                    <div class="bst-input-stack">
-                                        <input id="sonarrUrl" name="sonarrUrl" type="text" class="bst-input" placeholder="http://192.168.1.170:8989" />
-                                        <div class="bst-field-desc">URL used by the server to reach Sonarr (or you use to access it)</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="bst-input-group">
-                                <div class="bst-field-main">
-                                    <label class="bst-label bst-label--side bst-label--required" for="sonarrApiKey">Sonarr API Key</label>
-                                    <div class="bst-input-stack">
-                                        <input id="sonarrApiKey" name="sonarrApiKey" type="password" class="bst-input" autocomplete="off" />
-                                        <div class="bst-field-desc">Key for Sonarr which you can get from Sonarr → Settings → General → Security → API Key</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        <div id="bstServarrInstanceList" class="bst-servarr-instance-list"></div>
                     </div>
                 </div>
 
@@ -1731,6 +1756,74 @@
         </div>
     </div>
 
+    <template id="bstServarrInstanceTemplate">
+        <div class="bst-card bst-servarr-instance-card" data-servarr-kind="">
+            <div class="bst-servarr-instance-top">
+                <div class="bst-servarr-instance-title-wrap">
+                    <div class="bst-servarr-instance-kind" data-servarr-kind-label></div>
+                    <div class="bst-field-desc" data-servarr-kind-desc>Used for Requests progress and open links.</div>
+                </div>
+                <div class="bst-servarr-instance-actions">
+                    <label class="bst-toggle" title="Use as default">
+                        <input type="checkbox" data-servarr-field="isDefault" />
+                        <span class="bst-toggle-slider"></span>
+                    </label>
+                    <button type="button" class="bst-customize-btn" data-servarr-action="remove">Remove</button>
+                </div>
+            </div>
+            <div class="bst-input-row">
+                <div class="bst-input-group">
+                    <div class="bst-field-main">
+                        <label class="bst-label bst-label--side" data-servarr-label="name">Name</label>
+                        <div class="bst-input-stack">
+                            <input type="text" class="bst-input" data-servarr-field="name" />
+                        </div>
+                    </div>
+                </div>
+                <div class="bst-input-group">
+                    <div class="bst-field-main">
+                        <label class="bst-label bst-label--side" data-servarr-label="url">URL</label>
+                        <div class="bst-input-stack">
+                            <input type="text" class="bst-input" data-servarr-field="url" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="bst-input-row">
+                <div class="bst-input-group">
+                    <div class="bst-field-main">
+                        <label class="bst-label bst-label--side" data-servarr-label="apiKey">API Key</label>
+                        <div class="bst-input-stack">
+                            <input type="password" class="bst-input" data-servarr-field="apiKey" autocomplete="off" />
+                        </div>
+                    </div>
+                </div>
+                <div class="bst-input-group" data-servarr-role="4k-row">
+                    <div class="bst-toggle-row">
+                        <div class="bst-toggle-copy">
+                            <label class="bst-toggle-label" data-servarr-4k-label>4K Radarr</label>
+                            <div class="bst-field-desc">Marks this Radarr as the 4K target.</div>
+                        </div>
+                        <label class="bst-toggle" title="Mark as 4K target">
+                            <input type="checkbox" data-servarr-field="is4k" />
+                            <span class="bst-toggle-slider"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <div id="bstServarrAddModal" class="bst-modal-overlay" aria-hidden="true">
+        <div class="bst-modal bst-modal--compact" role="dialog" aria-modal="true" aria-labelledby="bstServarrAddModalTitle">
+            <h3 id="bstServarrAddModalTitle" class="bst-modal-title">Add Servarr instance</h3>
+            <div class="bst-modal-actions bst-modal-actions--stack">
+                <button type="button" class="bst-modal-btn bst-modal-btn--choice" data-servarr-add-kind="radarr">Add Radarr</button>
+                <button type="button" class="bst-modal-btn bst-modal-btn--choice" data-servarr-add-kind="sonarr">Add Sonarr</button>
+            </div>
+        </div>
+    </div>
+
     <script type="text/javascript">
         (function () {
             const pluginId = 'c8e4f2a1-9b3d-4e7f-a6c2-1d5e8f0a3b7c';
@@ -1772,11 +1865,397 @@
                 return el ? String(el.value || '').trim() : '';
             }
 
+            const servarrInstanceList = document.getElementById('bstServarrInstanceList');
+            const servarrInstanceTemplate = document.getElementById('bstServarrInstanceTemplate');
+            const servarrAddModal = document.getElementById('bstServarrAddModal');
+            const servarrAddButton = document.getElementById('bstAddServarrInstance');
+            let servarrInstanceIdCounter = 0;
+
+            function normalizeServarrKind(kind) {
+                return String(kind || '').toLowerCase() === 'sonarr' ? 'sonarr' : 'radarr';
+            }
+
+            function getServarrKindLabel(kind) {
+                return normalizeServarrKind(kind) === 'sonarr' ? 'Sonarr' : 'Radarr';
+            }
+
+            function getServarrDefaultName(kind, index) {
+                return getServarrKindLabel(kind) + ' ' + index;
+            }
+
+            function getServarrInstanceCards() {
+                return servarrInstanceList
+                    ? Array.from(servarrInstanceList.querySelectorAll('.bst-servarr-instance-card'))
+                    : [];
+            }
+
+            function getServarrInstanceCountsFromDom() {
+                return getServarrInstanceCards().reduce(function (counts, card) {
+                    const kind = normalizeServarrKind(card.getAttribute('data-servarr-kind'));
+                    const urlInput = card.querySelector('[data-servarr-field="url"]');
+                    const apiKeyInput = card.querySelector('[data-servarr-field="apiKey"]');
+                    if (String(urlInput && urlInput.value || '').trim() !== '' && String(apiKeyInput && apiKeyInput.value || '').trim() !== '') {
+                        counts[kind] += 1;
+                    }
+                    return counts;
+                }, { radarr: 0, sonarr: 0 });
+            }
+
+            function normalizeServarrInstancesFromConfig(config) {
+                const raw = Array.isArray(config.ServarrInstances || config.servarrInstances)
+                    ? (config.ServarrInstances || config.servarrInstances)
+                    : [];
+                const instances = [];
+                const kindCounts = { radarr: 0, sonarr: 0 };
+
+                function pushInstance(source, fallbackKind) {
+                    const kind = normalizeServarrKind(source && (source.Kind || source.kind || source.Type || source.type || fallbackKind));
+                    kindCounts[kind] += 1;
+                    const name = String(source && (source.Name || source.name) || '').trim() || getServarrDefaultName(kind, kindCounts[kind]);
+                    instances.push({
+                        Kind: kind,
+                        Name: name,
+                        Url: String(source && (source.Url || source.url) || '').trim(),
+                        ApiKey: String(source && (source.ApiKey || source.apiKey) || '').trim(),
+                        IsDefault: source && (source.IsDefault ?? source.isDefault) === true,
+                        Is4k: kind === 'radarr' && source && (source.Is4k ?? source.is4k) === true
+                    });
+                }
+
+                raw.forEach(function (instance) {
+                    pushInstance(instance, instance && (instance.Kind || instance.kind || instance.Type || instance.type));
+                });
+
+                if (!instances.length) {
+                    if (String(config.RadarrUrl || '').trim() !== '' || String(config.RadarrApiKey || '').trim() !== '') {
+                        pushInstance({
+                            Kind: 'radarr',
+                            Name: '',
+                            Url: config.RadarrUrl || '',
+                            ApiKey: config.RadarrApiKey || '',
+                            IsDefault: true,
+                            Is4k: false
+                        }, 'radarr');
+                    }
+
+                    if (String(config.SonarrUrl || '').trim() !== '' || String(config.SonarrApiKey || '').trim() !== '') {
+                        pushInstance({
+                            Kind: 'sonarr',
+                            Name: '',
+                            Url: config.SonarrUrl || '',
+                            ApiKey: config.SonarrApiKey || '',
+                            IsDefault: true,
+                            Is4k: false
+                        }, 'sonarr');
+                    }
+                }
+
+                ['radarr', 'sonarr'].forEach(function (kind) {
+                    const byKind = instances.filter(function (instance) {
+                        return normalizeServarrKind(instance.Kind) === kind;
+                    });
+                    if (!byKind.length) {
+                        return;
+                    }
+
+                    let defaultIndex = byKind.findIndex(function (instance) {
+                        return instance.IsDefault === true;
+                    });
+                    if (defaultIndex < 0) {
+                        defaultIndex = 0;
+                    }
+
+                    byKind.forEach(function (instance, index) {
+                        instance.IsDefault = index === defaultIndex;
+                    });
+                });
+
+                return instances;
+            }
+
+            function updateServarrDefaultState(kind, activeCheckbox) {
+                if (!servarrInstanceList || !activeCheckbox || !activeCheckbox.checked) {
+                    return;
+                }
+
+                const normalizedKind = normalizeServarrKind(kind);
+                getServarrInstanceCards().forEach(function (card) {
+                    if (normalizeServarrKind(card.getAttribute('data-servarr-kind')) !== normalizedKind) {
+                        return;
+                    }
+                    const checkbox = card.querySelector('[data-servarr-field="isDefault"]');
+                    if (checkbox && checkbox !== activeCheckbox) {
+                        checkbox.checked = false;
+                    }
+                });
+            }
+
+            function repairServarrDefaults(kind) {
+                const normalizedKind = normalizeServarrKind(kind);
+                const cards = getServarrInstanceCards().filter(function (card) {
+                    return normalizeServarrKind(card.getAttribute('data-servarr-kind')) === normalizedKind;
+                });
+                if (!cards.length) {
+                    return;
+                }
+
+                const anyDefault = cards.some(function (card) {
+                    const checkbox = card.querySelector('[data-servarr-field="isDefault"]');
+                    return checkbox && checkbox.checked === true;
+                });
+                if (!anyDefault) {
+                    const checkbox = cards[0].querySelector('[data-servarr-field="isDefault"]');
+                    if (checkbox) {
+                        checkbox.checked = true;
+                    }
+                }
+            }
+
+            function createServarrInstanceCard(instance) {
+                if (!servarrInstanceTemplate || !servarrInstanceTemplate.content) {
+                    return null;
+                }
+
+                const kind = normalizeServarrKind(instance && instance.Kind);
+                const uid = 'servarr-' + (++servarrInstanceIdCounter);
+                const fragment = servarrInstanceTemplate.content.cloneNode(true);
+                const card = fragment.querySelector('.bst-servarr-instance-card');
+                if (!card) {
+                    return null;
+                }
+
+                card.setAttribute('data-servarr-kind', kind);
+                card.setAttribute('data-servarr-uid', uid);
+
+                const kindLabel = card.querySelector('[data-servarr-kind-label]');
+                if (kindLabel) {
+                    kindLabel.textContent = getServarrKindLabel(kind) + ' instance';
+                }
+
+                const nameLabel = card.querySelector('[data-servarr-label="name"]');
+                const urlLabel = card.querySelector('[data-servarr-label="url"]');
+                const apiKeyLabel = card.querySelector('[data-servarr-label="apiKey"]');
+                const nameInput = card.querySelector('[data-servarr-field="name"]');
+                const urlInput = card.querySelector('[data-servarr-field="url"]');
+                const apiKeyInput = card.querySelector('[data-servarr-field="apiKey"]');
+                const defaultInput = card.querySelector('[data-servarr-field="isDefault"]');
+                const kindDesc = card.querySelector('[data-servarr-kind-desc]');
+                const kind4kRow = card.querySelector('[data-servarr-role="4k-row"]');
+                const kind4kLabel = card.querySelector('[data-servarr-4k-label]');
+                const removeButton = card.querySelector('[data-servarr-action="remove"]');
+
+                if (nameLabel && nameInput) {
+                    const nameId = uid + '-name';
+                    nameLabel.setAttribute('for', nameId);
+                    nameInput.id = nameId;
+                }
+
+                if (urlLabel && urlInput) {
+                    const urlId = uid + '-url';
+                    urlLabel.setAttribute('for', urlId);
+                    urlInput.id = urlId;
+                }
+
+                if (apiKeyLabel && apiKeyInput) {
+                    const apiKeyId = uid + '-api-key';
+                    apiKeyLabel.setAttribute('for', apiKeyId);
+                    apiKeyInput.id = apiKeyId;
+                }
+
+                if (nameInput) {
+                    nameInput.value = instance.Name || '';
+                }
+
+                if (urlInput) {
+                    urlInput.value = instance.Url || '';
+                    urlInput.placeholder = kind === 'sonarr'
+                        ? 'http://192.168.1.170:8989'
+                        : 'http://192.168.1.170:7878';
+                }
+
+                if (apiKeyInput) {
+                    apiKeyInput.value = instance.ApiKey || '';
+                }
+
+                if (defaultInput) {
+                    defaultInput.checked = instance.IsDefault === true;
+                }
+
+                if (kindDesc) {
+                    kindDesc.textContent = 'Used for Requests progress and open links.';
+                }
+
+                if (kind4kRow) {
+                    kind4kRow.hidden = kind !== 'radarr';
+                }
+
+                if (kind4kLabel) {
+                    kind4kLabel.textContent = '4K ' + getServarrKindLabel(kind);
+                }
+
+                if (defaultInput) {
+                    defaultInput.addEventListener('change', function () {
+                        updateServarrDefaultState(kind, defaultInput);
+                        updateConfigSummary();
+                    });
+                }
+
+                if (removeButton) {
+                    removeButton.addEventListener('click', function () {
+                        const removedKind = normalizeServarrKind(card.getAttribute('data-servarr-kind'));
+                        card.remove();
+                        repairServarrDefaults(removedKind);
+                        updateConfigSummary();
+                    });
+                }
+
+                return card;
+            }
+
+            function renderServarrInstances(instances) {
+                if (!servarrInstanceList) {
+                    return;
+                }
+
+                servarrInstanceList.innerHTML = '';
+                (Array.isArray(instances) ? instances : []).forEach(function (instance) {
+                    const card = createServarrInstanceCard(instance);
+                    if (card) {
+                        servarrInstanceList.appendChild(card);
+                    }
+                });
+                repairServarrDefaults('radarr');
+                repairServarrDefaults('sonarr');
+                updateConfigSummary();
+            }
+
+            function addServarrInstance(kind) {
+                const normalizedKind = normalizeServarrKind(kind);
+                const count = getServarrInstanceCards().filter(function (card) {
+                    return normalizeServarrKind(card.getAttribute('data-servarr-kind')) === normalizedKind;
+                }).length + 1;
+                const card = createServarrInstanceCard({
+                    Kind: normalizedKind,
+                    Name: getServarrDefaultName(normalizedKind, count),
+                    Url: '',
+                    ApiKey: '',
+                    IsDefault: count === 1,
+                    Is4k: false
+                });
+                if (card && servarrInstanceList) {
+                    servarrInstanceList.appendChild(card);
+                    repairServarrDefaults(normalizedKind);
+                    updateConfigSummary();
+                    const focusInput = card.querySelector('[data-servarr-field="name"]');
+                    if (focusInput) {
+                        focusInput.focus();
+                        focusInput.select();
+                    }
+                }
+            }
+
+            function collectServarrInstancesPayload() {
+                const cards = getServarrInstanceCards();
+                const instances = cards.map(function (card) {
+                    const kind = normalizeServarrKind(card.getAttribute('data-servarr-kind'));
+                    const nameInput = card.querySelector('[data-servarr-field="name"]');
+                    const urlInput = card.querySelector('[data-servarr-field="url"]');
+                    const apiKeyInput = card.querySelector('[data-servarr-field="apiKey"]');
+                    const defaultInput = card.querySelector('[data-servarr-field="isDefault"]');
+                    const is4kInput = card.querySelector('[data-servarr-field="is4k"]');
+                    return {
+                        Kind: kind,
+                        Name: String(nameInput && nameInput.value || '').trim(),
+                        Url: String(urlInput && urlInput.value || '').trim(),
+                        ApiKey: String(apiKeyInput && apiKeyInput.value || '').trim(),
+                        DefaultChecked: defaultInput && defaultInput.checked === true,
+                        Is4k: kind === 'radarr' && is4kInput ? is4kInput.checked === true : false
+                    };
+                }).filter(function (instance) {
+                    return instance.Url !== '' || instance.ApiKey !== '';
+                });
+
+                const defaultByKind = { radarr: -1, sonarr: -1 };
+                const nameCounters = { radarr: 0, sonarr: 0 };
+
+                instances.forEach(function (instance, index) {
+                    const kind = normalizeServarrKind(instance.Kind);
+                    if (defaultByKind[kind] < 0 && instance.DefaultChecked === true) {
+                        defaultByKind[kind] = index;
+                    }
+                });
+
+                instances.forEach(function (instance, index) {
+                    const kind = normalizeServarrKind(instance.Kind);
+                    if (defaultByKind[kind] < 0) {
+                        defaultByKind[kind] = index;
+                    }
+                });
+
+                return instances.map(function (instance, index) {
+                    const kind = normalizeServarrKind(instance.Kind);
+                    nameCounters[kind] += 1;
+                    return {
+                        Kind: kind,
+                        Name: instance.Name || getServarrDefaultName(kind, nameCounters[kind]),
+                        Url: instance.Url,
+                        ApiKey: instance.ApiKey,
+                        IsDefault: index === defaultByKind[kind],
+                        Is4k: kind === 'radarr' && instance.Is4k
+                    };
+                });
+            }
+
+            function syncLegacyServarrFields(config, instances) {
+                function findPreferred(kind) {
+                    const normalizedKind = normalizeServarrKind(kind);
+                    const byKind = instances.filter(function (instance) {
+                        return normalizeServarrKind(instance.Kind) === normalizedKind;
+                    });
+                    const configured = byKind.filter(function (instance) {
+                        return String(instance.Url || '').trim() !== '' &&
+                            String(instance.ApiKey || '').trim() !== '';
+                    });
+                    return configured.find(function (instance) {
+                        return instance.IsDefault === true;
+                    }) || configured[0] || byKind.find(function (instance) {
+                        return instance.IsDefault === true;
+                    }) || byKind[0] || null;
+                }
+
+                const radarr = findPreferred('radarr');
+                const sonarr = findPreferred('sonarr');
+
+                config.RadarrUrl = radarr ? radarr.Url : '';
+                config.RadarrApiKey = radarr ? radarr.ApiKey : '';
+                config.SonarrUrl = sonarr ? sonarr.Url : '';
+                config.SonarrApiKey = sonarr ? sonarr.ApiKey : '';
+            }
+
+            function openServarrAddModal() {
+                if (!servarrAddModal) {
+                    return;
+                }
+
+                servarrAddModal.classList.add('is-open');
+                servarrAddModal.setAttribute('aria-hidden', 'false');
+            }
+
+            function closeServarrAddModal() {
+                if (!servarrAddModal) {
+                    return;
+                }
+
+                servarrAddModal.classList.remove('is-open');
+                servarrAddModal.setAttribute('aria-hidden', 'true');
+            }
+
             function updateConfigSummary() {
                 setSummaryRow('bstCfgSeerr', fieldValue('jellyseerrUrl') !== '' && fieldValue('jellyseerrApiKey') !== '');
                 setSummaryRow('bstCfgTmdb', fieldValue('tmdbApiKey') !== '');
-                setSummaryRow('bstCfgRadarr', fieldValue('radarrUrl') !== '' && fieldValue('radarrApiKey') !== '');
-                setSummaryRow('bstCfgSonarr', fieldValue('sonarrUrl') !== '' && fieldValue('sonarrApiKey') !== '');
+                const counts = getServarrInstanceCountsFromDom();
+                setSummaryRow('bstCfgRadarr', counts.radarr > 0);
+                setSummaryRow('bstCfgSonarr', counts.sonarr > 0);
             }
 
             const TAB_TITLES = {
@@ -2166,13 +2645,59 @@
             }
 
             function bindConfigSummaryListeners() {
-                ['jellyseerrUrl', 'jellyseerrApiKey', 'tmdbApiKey', 'radarrUrl', 'radarrApiKey', 'sonarrUrl', 'sonarrApiKey'].forEach(function (id) {
+                ['jellyseerrUrl', 'jellyseerrApiKey', 'tmdbApiKey'].forEach(function (id) {
                     const el = document.getElementById(id);
                     if (el) {
                         el.addEventListener('input', updateConfigSummary);
                         el.addEventListener('change', updateConfigSummary);
                     }
                 });
+
+                if (servarrInstanceList && servarrInstanceList.dataset.bstBound !== 'true') {
+                    servarrInstanceList.dataset.bstBound = 'true';
+                    servarrInstanceList.addEventListener('input', updateConfigSummary);
+                    servarrInstanceList.addEventListener('change', function (event) {
+                        const target = event.target.closest('[data-servarr-field]');
+                        if (!target) {
+                            return;
+                        }
+
+                        if (target.getAttribute('data-servarr-field') === 'isDefault') {
+                            const card = target.closest('.bst-servarr-instance-card');
+                            if (card) {
+                                updateServarrDefaultState(card.getAttribute('data-servarr-kind'), target);
+                                repairServarrDefaults(card.getAttribute('data-servarr-kind'));
+                            }
+                        }
+
+                        updateConfigSummary();
+                    });
+                }
+
+                if (servarrAddButton && servarrAddButton.dataset.bstBound !== 'true') {
+                    servarrAddButton.dataset.bstBound = 'true';
+                    servarrAddButton.addEventListener('click', function () {
+                        openServarrAddModal();
+                    });
+                }
+
+                if (servarrAddModal && servarrAddModal.dataset.bstBound !== 'true') {
+                    servarrAddModal.dataset.bstBound = 'true';
+                    servarrAddModal.addEventListener('click', function (event) {
+                        if (event.target === servarrAddModal) {
+                            closeServarrAddModal();
+                            return;
+                        }
+
+                        const choice = event.target.closest('[data-servarr-add-kind]');
+                        if (!choice) {
+                            return;
+                        }
+
+                        addServarrInstance(choice.getAttribute('data-servarr-add-kind'));
+                        closeServarrAddModal();
+                    });
+                }
             }
 
             document.querySelectorAll('.bst-page-nav-btn[data-bst-panel]').forEach(function (btn) {
@@ -2659,8 +3184,17 @@
             }
 
             document.addEventListener('keydown', function (event) {
-                if (event.key === 'Escape' && customizeModal && customizeModal.classList.contains('is-open')) {
+                if (event.key !== 'Escape') {
+                    return;
+                }
+
+                if (customizeModal && customizeModal.classList.contains('is-open')) {
                     closeCustomizeModal();
+                    return;
+                }
+
+                if (servarrAddModal && servarrAddModal.classList.contains('is-open')) {
+                    closeServarrAddModal();
                 }
             });
 
@@ -2723,13 +3257,10 @@
                     customTabsForeign
                 );
                 syncTabCardsFromState();
+                renderServarrInstances(normalizeServarrInstancesFromConfig(config));
                 document.querySelector('#jellyseerrUrl').value = config.JellyseerrUrl || '';
                 document.querySelector('#externalJellyseerrUrl').value = config.ExternalJellyseerrUrl || '';
                 document.querySelector('#jellyseerrApiKey').value = config.JellyseerrApiKey || '';
-                document.querySelector('#radarrUrl').value = config.RadarrUrl || '';
-                document.querySelector('#radarrApiKey').value = config.RadarrApiKey || '';
-                document.querySelector('#sonarrUrl').value = config.SonarrUrl || '';
-                document.querySelector('#sonarrApiKey').value = config.SonarrApiKey || '';
                 document.querySelector('#jellyseerrPreferredLanguages').value = config.JellyseerrPreferredLanguages || 'en';
                 document.querySelector('#watchRegion').value = config.WatchRegion || 'US';
                 document.querySelector('#rowItemLimit').value = config.RowItemLimit || 20;
@@ -2757,6 +3288,7 @@
                 customTabsForeign = [];
                 tabBarOrder = normalizeBarOrder([], customTabsForeign);
                 syncTabCardsFromState();
+                renderServarrInstances([]);
                 Dashboard.hideLoadingMsg();
             });
 
@@ -2770,10 +3302,8 @@
                     config.JellyseerrUrl = document.querySelector('#jellyseerrUrl').value;
                     config.ExternalJellyseerrUrl = document.querySelector('#externalJellyseerrUrl').value;
                     config.JellyseerrApiKey = document.querySelector('#jellyseerrApiKey').value;
-                    config.RadarrUrl = document.querySelector('#radarrUrl').value.trim();
-                    config.RadarrApiKey = document.querySelector('#radarrApiKey').value.trim();
-                    config.SonarrUrl = document.querySelector('#sonarrUrl').value.trim();
-                    config.SonarrApiKey = document.querySelector('#sonarrApiKey').value.trim();
+                    config.ServarrInstances = collectServarrInstancesPayload();
+                    syncLegacyServarrFields(config, config.ServarrInstances);
                     config.JellyseerrPreferredLanguages = document.querySelector('#jellyseerrPreferredLanguages').value;
                     config.WatchRegion = document.querySelector('#watchRegion').value || 'US';
                     config.RowItemLimit = parseInt(document.querySelector('#rowItemLimit').value, 10) || 20;

--- a/src/Jellyfin.Plugin.SeerrFin/Controllers/SeerrFinController.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Controllers/SeerrFinController.cs
@@ -168,7 +168,12 @@ public class SeerrFinController : ControllerBase
 
     [HttpGet("Configuration")]
     [Authorize(Roles = "Administrator")]
-    public ActionResult<PluginConfiguration> GetConfiguration() => SeerrFinPlugin.Instance.Configuration;
+    public ActionResult<PluginConfiguration> GetConfiguration()
+    {
+        PluginConfiguration config = SeerrFinPlugin.Instance.Configuration;
+        ServarrConfigHelper.Resolve(config);
+        return config;
+    }
 
     [HttpGet("display-settings")]
     [Authorize]
@@ -505,6 +510,8 @@ public class SeerrFinController : ControllerBase
     public ActionResult GetClientSettings()
     {
         PluginConfiguration config = SeerrFinPlugin.Instance.Configuration;
+        IReadOnlyList<ServarrInstanceConfig> radarrInstances = ServarrConfigHelper.GetConfiguredInstances(config, "radarr");
+        IReadOnlyList<ServarrInstanceConfig> sonarrInstances = ServarrConfigHelper.GetConfiguredInstances(config, "sonarr");
         string? key = config.TmdbApiKey?.Trim();
         string? browseUrl = config.ExternalJellyseerrUrl?.Trim();
         if (string.IsNullOrEmpty(browseUrl))
@@ -516,15 +523,25 @@ public class SeerrFinController : ControllerBase
         {
             tmdbApiKey = key ?? string.Empty,
             jellyseerrBrowseUrl = browseUrl ?? string.Empty,
-            radarrUrl = IsServarrBrowseUrlConfigured(config.RadarrUrl, config.RadarrApiKey),
-            sonarrUrl = IsServarrBrowseUrlConfigured(config.SonarrUrl, config.SonarrApiKey)
+            hasRadarr = radarrInstances.Count > 0,
+            hasSonarr = sonarrInstances.Count > 0,
+            radarrUrl = ServarrConfigHelper.GetPreferredUrl(config, "radarr") ?? string.Empty,
+            sonarrUrl = ServarrConfigHelper.GetPreferredUrl(config, "sonarr") ?? string.Empty,
+            radarrInstances = radarrInstances.Select(instance => new
+            {
+                name = instance.Name ?? string.Empty,
+                url = instance.Url ?? string.Empty,
+                isDefault = instance.IsDefault,
+                is4k = instance.Is4k
+            }),
+            sonarrInstances = sonarrInstances.Select(instance => new
+            {
+                name = instance.Name ?? string.Empty,
+                url = instance.Url ?? string.Empty,
+                isDefault = instance.IsDefault
+            })
         });
     }
-
-    private static string IsServarrBrowseUrlConfigured(string? url, string? apiKey) =>
-        !string.IsNullOrWhiteSpace(url) && !string.IsNullOrWhiteSpace(apiKey)
-            ? url.Trim().TrimEnd('/')
-            : string.Empty;
 
     [HttpGet("details/{mediaType}/{mediaId}")]
     [Authorize]

--- a/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-requests.js
+++ b/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-requests.js
@@ -61,17 +61,27 @@ window.seerrFinLog = window.seerrFinLog || {
             type: 'GET',
             dataType: 'json'
         }).then(function (config) {
+            const radarrInstances = Array.isArray(config.radarrInstances) ? config.radarrInstances : [];
+            const sonarrInstances = Array.isArray(config.sonarrInstances) ? config.sonarrInstances : [];
             state.clientSettings = {
                 jellyseerrBrowseUrl: (config.jellyseerrBrowseUrl || '').replace(/\/+$/, ''),
-                radarrUrl: (config.radarrUrl || '').replace(/\/+$/, ''),
-                sonarrUrl: (config.sonarrUrl || '').replace(/\/+$/, '')
+                hasRadarr: config.hasRadarr === true || radarrInstances.length > 0 || !!config.radarrUrl,
+                hasSonarr: config.hasSonarr === true || sonarrInstances.length > 0 || !!config.sonarrUrl,
+                radarrUrl: ((config.radarrUrl || (radarrInstances[0] && radarrInstances[0].url)) || '').replace(/\/+$/, ''),
+                sonarrUrl: ((config.sonarrUrl || (sonarrInstances[0] && sonarrInstances[0].url)) || '').replace(/\/+$/, ''),
+                radarrInstances: radarrInstances,
+                sonarrInstances: sonarrInstances
             };
         }).catch(function (err) {
             log.warn('client settings fetch failed', err);
             state.clientSettings = {
                 jellyseerrBrowseUrl: '',
+                hasRadarr: false,
+                hasSonarr: false,
                 radarrUrl: '',
-                sonarrUrl: ''
+                sonarrUrl: '',
+                radarrInstances: [],
+                sonarrInstances: []
             };
         });
     }
@@ -112,6 +122,27 @@ window.seerrFinLog = window.seerrFinLog || {
         }
 
         window.open(url, '_blank', 'noopener,noreferrer');
+    }
+
+    function getPreferredServarrInstanceUrl(instances, prefer4k) {
+        const list = Array.isArray(instances) ? instances : [];
+        if (!list.length) {
+            return '';
+        }
+
+        const preferred = typeof prefer4k === 'boolean'
+            ? list.filter(function (instance) {
+                return prefer4k ? instance.is4k === true : instance.is4k !== true;
+            })
+            : list;
+        const pool = preferred.length > 0 ? preferred : list;
+        const selected = pool.find(function (instance) {
+            return instance.isDefault === true && String(instance.url || '').trim() !== '';
+        }) || pool.find(function (instance) {
+            return String(instance.url || '').trim() !== '';
+        }) || null;
+
+        return selected ? String(selected.url || '').replace(/\/+$/, '') : '';
     }
 
     function escapeHtml(text) {
@@ -304,9 +335,15 @@ window.seerrFinLog = window.seerrFinLog || {
         }
 
         const mediaType = item.type === 'tv' ? 'tv' : 'movie';
-        const base = mediaType === 'tv'
+        const instances = mediaType === 'tv'
+            ? state.clientSettings?.sonarrInstances
+            : state.clientSettings?.radarrInstances;
+        const base = getPreferredServarrInstanceUrl(
+            instances,
+            mediaType === 'movie' ? item.is4k === true : undefined
+        ) || (mediaType === 'tv'
             ? state.clientSettings?.sonarrUrl
-            : state.clientSettings?.radarrUrl;
+            : state.clientSettings?.radarrUrl);
         if (!base || !item.tmdbId) {
             return '';
         }
@@ -319,10 +356,17 @@ window.seerrFinLog = window.seerrFinLog || {
             return;
         }
 
-        const safeTitle = escapeHtml(item.title || 'content');
+        const titleText = item.title || 'content';
+        const safeTitle = escapeHtml(titleText);
         const mediaType = item.type === 'tv' ? 'tv' : 'movie';
         const safeTmdbId = escapeHtml(String(item.tmdbId));
         const safeMediaType = escapeHtml(mediaType);
+        const progress = getServarrProgress(item);
+        const instanceSuffixText = progress?.instanceName ? ` (${progress.instanceName})` : '';
+        const radarrTitleText = `Open ${titleText} in Radarr${instanceSuffixText}`;
+        const sonarrTitleText = `Open ${titleText} in Sonarr${instanceSuffixText}`;
+        const radarrTooltipText = `Open in Radarr${instanceSuffixText}`;
+        const sonarrTooltipText = `Open in Sonarr${instanceSuffixText}`;
 
         const playBtn = isPlayableRequest(item) ? `
             <button type="button" class="seerrfin-request-action-btn seerrfin-request-play-btn"
@@ -332,26 +376,26 @@ window.seerrFinLog = window.seerrFinLog || {
             </button>` : '';
 
         let radarrBtn = '';
-        if (mediaType === 'movie' && state.clientSettings?.radarrUrl) {
+        if (mediaType === 'movie' && (state.clientSettings?.hasRadarr || state.clientSettings?.radarrUrl)) {
             const radarrUrl = getServarrOpenUrl(item);
             if (radarrUrl) {
                 radarrBtn = `
             <button type="button" class="seerrfin-request-action-btn seerrfin-request-radarr-btn"
                 data-open-url="${escapeHtml(radarrUrl)}"
-                aria-label="Open ${safeTitle} in Radarr" title="Open in Radarr">
+                aria-label="${escapeHtml(radarrTitleText)}" title="${escapeHtml(radarrTooltipText)}">
                 ${RADARR_LOGO}
             </button>`;
             }
         }
 
         let sonarrBtn = '';
-        if (mediaType === 'tv' && state.clientSettings?.sonarrUrl) {
+        if (mediaType === 'tv' && (state.clientSettings?.hasSonarr || state.clientSettings?.sonarrUrl)) {
             const sonarrUrl = getServarrOpenUrl(item);
             if (sonarrUrl) {
                 sonarrBtn = `
             <button type="button" class="seerrfin-request-action-btn seerrfin-request-sonarr-btn"
                 data-open-url="${escapeHtml(sonarrUrl)}"
-                aria-label="Open ${safeTitle} in Sonarr" title="Open in Sonarr">
+                aria-label="${escapeHtml(sonarrTitleText)}" title="${escapeHtml(sonarrTooltipText)}">
                 ${SONARR_LOGO}
             </button>`;
             }
@@ -449,7 +493,8 @@ window.seerrFinLog = window.seerrFinLog || {
             percent: raw.percent ?? raw.Percent ?? 0,
             downloadedBytes: raw.downloadedBytes ?? raw.DownloadedBytes ?? 0,
             totalBytes: raw.totalBytes ?? raw.TotalBytes ?? 0,
-            isActive: raw.isActive ?? raw.IsActive ?? false
+            isActive: raw.isActive ?? raw.IsActive ?? false,
+            instanceName: raw.instanceName || raw.InstanceName || ''
         };
     }
 
@@ -465,13 +510,15 @@ window.seerrFinLog = window.seerrFinLog || {
         const isTransfer = !isFailed && progress.isActive === true && (
             progress.statusKey === 'queued' || progress.statusKey.indexOf('downloaded-') === 0
         );
+        const instanceSuffixText = progress.instanceName ? ` · ${progress.instanceName}` : '';
 
         const percentText = isFailed ? 'Failed' : (isTransfer ? `${percent}%` : '0%');
-        const detailText = isFailed
+        const detailBase = isFailed
             ? 'Failed to find content'
             : (isTransfer
                 ? `${formatBytes(progress.downloadedBytes)}/${formatBytes(progress.totalBytes)}`
                 : (progress.statusLabel || ''));
+        const detailText = detailBase + instanceSuffixText;
 
         return `
             <div class="seerrfin-request-progress" data-status="${statusKey}">

--- a/src/Jellyfin.Plugin.SeerrFin/SeerrFinPlugin.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/SeerrFinPlugin.cs
@@ -22,6 +22,7 @@ public class SeerrFinPlugin : BasePlugin<PluginConfiguration>, IHasPluginConfigu
         // Normalize cached instance once on load. without this SaveConfiguration could stay a partial tab list.
         Configuration.Tabs = SeerrFinTabConfigHelper.Normalize(Configuration.Tabs);
         Configuration.TabBarOrder = SeerrFinTabConfigHelper.NormalizeBarOrder(Configuration.TabBarOrder);
+        ServarrConfigHelper.Resolve(Configuration);
     }
 
     public IEnumerable<PluginPageInfo> GetPages()
@@ -44,6 +45,7 @@ public class SeerrFinPlugin : BasePlugin<PluginConfiguration>, IHasPluginConfigu
         {
             config.Tabs = SeerrFinTabConfigHelper.Normalize(config.Tabs);
             config.TabBarOrder = SeerrFinTabConfigHelper.NormalizeBarOrder(config.TabBarOrder);
+            ServarrConfigHelper.Resolve(config);
         }
 
         base.UpdateConfiguration(configuration);

--- a/src/Jellyfin.Plugin.SeerrFin/Services/ServarrProgressService.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Services/ServarrProgressService.cs
@@ -18,7 +18,9 @@ public sealed class ServarrProgressService
     public async Task EnrichRequestsAsync(JArray requests, CancellationToken cancellationToken)
     {
         PluginConfiguration config = SeerrFinPlugin.Instance.Configuration;
-        if (!IsRadarrConfigured(config) && !IsSonarrConfigured(config))
+        IReadOnlyList<ServarrInstanceConfig> radarrInstances = ServarrConfigHelper.GetConfiguredInstances(config, "radarr");
+        IReadOnlyList<ServarrInstanceConfig> sonarrInstances = ServarrConfigHelper.GetConfiguredInstances(config, "sonarr");
+        if (radarrInstances.Count == 0 && sonarrInstances.Count == 0)
         {
             return;
         }
@@ -35,19 +37,19 @@ public sealed class ServarrProgressService
             return;
         }
 
-        RadarrSnapshot? radarrSnapshot = IsRadarrConfigured(config)
-            ? await LoadRadarrSnapshotAsync(config, contexts, cancellationToken).ConfigureAwait(false)
-            : null;
+        List<RadarrSnapshot> radarrSnapshots = radarrInstances.Count > 0
+            ? await LoadRadarrSnapshotsAsync(radarrInstances, contexts, cancellationToken).ConfigureAwait(false)
+            : new List<RadarrSnapshot>();
 
-        SonarrSnapshot? sonarrSnapshot = IsSonarrConfigured(config)
-            ? await LoadSonarrSnapshotAsync(config, contexts, cancellationToken).ConfigureAwait(false)
-            : null;
+        List<SonarrSnapshot> sonarrSnapshots = sonarrInstances.Count > 0
+            ? await LoadSonarrSnapshotsAsync(sonarrInstances, contexts, cancellationToken).ConfigureAwait(false)
+            : new List<SonarrSnapshot>();
 
         foreach (ServarrRequestContext context in contexts)
         {
             ServarrProgressInfo? progress = string.Equals(context.Type, "tv", StringComparison.OrdinalIgnoreCase)
-                ? BuildSeriesProgress(context, sonarrSnapshot)
-                : BuildMovieProgress(context, radarrSnapshot);
+                ? BuildSeriesProgress(context, ResolveSonarrSnapshot(context, sonarrSnapshots))
+                : BuildMovieProgress(context, ResolveRadarrSnapshot(context, radarrSnapshots));
 
             if (progress != null)
             {
@@ -59,15 +61,12 @@ public sealed class ServarrProgressService
                     ["downloadedBytes"] = progress.DownloadedBytes,
                     ["totalBytes"] = progress.TotalBytes,
                     ["isActive"] = progress.IsActive,
-                    ["openUrl"] = progress.OpenUrl
+                    ["openUrl"] = progress.OpenUrl,
+                    ["instanceName"] = progress.InstanceName
                 };
             }
         }
     }
-
-    private static bool IsRadarrConfigured(PluginConfiguration config) => !string.IsNullOrWhiteSpace(config.RadarrUrl) && !string.IsNullOrWhiteSpace(config.RadarrApiKey);
-
-    private static bool IsSonarrConfigured(PluginConfiguration config) => !string.IsNullOrWhiteSpace(config.SonarrUrl) && !string.IsNullOrWhiteSpace(config.SonarrApiKey);
 
     private static ServarrRequestContext? BuildContext(JObject request)
     {
@@ -84,14 +83,43 @@ public sealed class ServarrProgressService
             .Select(v => v!.Value)
             .ToHashSet() ?? new HashSet<int>();
 
-        return new ServarrRequestContext(request, type, tmdbId.Value, request.Value<int?>("externalServiceId"), seasonNumbers);
+        bool is4k = request.Value<bool?>("is4k") ?? false;
+
+        return new ServarrRequestContext(request, type, tmdbId.Value, request.Value<int?>("externalServiceId"), seasonNumbers, is4k);
     }
 
-    private async Task<RadarrSnapshot?> LoadRadarrSnapshotAsync(PluginConfiguration config, IReadOnlyCollection<ServarrRequestContext> contexts, CancellationToken cancellationToken)
+    private async Task<List<RadarrSnapshot>> LoadRadarrSnapshotsAsync(
+        IReadOnlyCollection<ServarrInstanceConfig> instances,
+        IReadOnlyCollection<ServarrRequestContext> contexts,
+        CancellationToken cancellationToken)
+    {
+        RadarrSnapshot?[] snapshots = await Task.WhenAll(
+                instances.Select(instance => LoadRadarrSnapshotAsync(instance, contexts, cancellationToken)))
+            .ConfigureAwait(false);
+
+        return snapshots.Where(snapshot => snapshot != null).Cast<RadarrSnapshot>().ToList();
+    }
+
+    private async Task<List<SonarrSnapshot>> LoadSonarrSnapshotsAsync(
+        IReadOnlyCollection<ServarrInstanceConfig> instances,
+        IReadOnlyCollection<ServarrRequestContext> contexts,
+        CancellationToken cancellationToken)
+    {
+        SonarrSnapshot?[] snapshots = await Task.WhenAll(
+                instances.Select(instance => LoadSonarrSnapshotAsync(instance, contexts, cancellationToken)))
+            .ConfigureAwait(false);
+
+        return snapshots.Where(snapshot => snapshot != null).Cast<SonarrSnapshot>().ToList();
+    }
+
+    private async Task<RadarrSnapshot?> LoadRadarrSnapshotAsync(
+        ServarrInstanceConfig instance,
+        IReadOnlyCollection<ServarrRequestContext> contexts,
+        CancellationToken cancellationToken)
     {
         try
         {
-            using HttpClient client = CreateClient(config.RadarrUrl!, config.RadarrApiKey!);
+            using HttpClient client = CreateClient(instance.Url!, instance.ApiKey!);
             List<JObject> queueRecords = await FetchAllQueueRecordsAsync(client, includeMovie: true, cancellationToken)
                 .ConfigureAwait(false);
 
@@ -147,20 +175,30 @@ public sealed class ServarrProgressService
                 }
             }
 
-            return new RadarrSnapshot(NormalizeServarrBaseUrl(config.RadarrUrl!), moviesByTmdbId, queueByMovieId, queueByTmdbId);
+            return new RadarrSnapshot(
+                instance.Name?.Trim() ?? ServarrConfigHelper.GetKindLabel(instance.Kind),
+                instance.IsDefault,
+                instance.Is4k,
+                NormalizeServarrBaseUrl(instance.Url!),
+                moviesByTmdbId,
+                queueByMovieId,
+                queueByTmdbId);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "SF • failed to load Radarr progress snapshot from {RadarrUrl}", config.RadarrUrl);
+            _logger.LogWarning(ex, "SF • failed to load Radarr progress snapshot from {RadarrUrl} ({Name})", instance.Url, instance.Name);
             return null;
         }
     }
 
-    private async Task<SonarrSnapshot?> LoadSonarrSnapshotAsync(PluginConfiguration config, IReadOnlyCollection<ServarrRequestContext> contexts, CancellationToken cancellationToken)
+    private async Task<SonarrSnapshot?> LoadSonarrSnapshotAsync(
+        ServarrInstanceConfig instance,
+        IReadOnlyCollection<ServarrRequestContext> contexts,
+        CancellationToken cancellationToken)
     {
         try
         {
-            using HttpClient client = CreateClient(config.SonarrUrl!, config.SonarrApiKey!);
+            using HttpClient client = CreateClient(instance.Url!, instance.ApiKey!);
             List<JObject> queueRecords = await FetchAllQueueRecordsAsync(client, includeMovie: false, cancellationToken)
                 .ConfigureAwait(false);
 
@@ -240,13 +278,46 @@ public sealed class ServarrProgressService
                 }
             }
 
-            return new SonarrSnapshot(NormalizeServarrBaseUrl(config.SonarrUrl!), seriesByTmdbId, episodesBySeriesId, queueBySeriesId);
+            return new SonarrSnapshot(
+                instance.Name?.Trim() ?? ServarrConfigHelper.GetKindLabel(instance.Kind),
+                instance.IsDefault,
+                NormalizeServarrBaseUrl(instance.Url!),
+                seriesByTmdbId,
+                episodesBySeriesId,
+                queueBySeriesId);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "SF • failed to load Sonarr progress snapshot from {SonarrUrl}", config.SonarrUrl);
+            _logger.LogWarning(ex, "SF • failed to load Sonarr progress snapshot from {SonarrUrl} ({Name})", instance.Url, instance.Name);
             return null;
         }
+    }
+
+    private static RadarrSnapshot? ResolveRadarrSnapshot(ServarrRequestContext context, IReadOnlyCollection<RadarrSnapshot> snapshots)
+    {
+        if (snapshots.Count == 0)
+        {
+            return null;
+        }
+
+        List<RadarrSnapshot> matches = snapshots.Where(snapshot => snapshot.Matches(context)).ToList();
+        List<RadarrSnapshot> preferred = matches.Where(snapshot => snapshot.Is4k == context.Is4k).ToList();
+        IReadOnlyCollection<RadarrSnapshot> pool = preferred.Count > 0 ? preferred : matches.Count > 0 ? matches : snapshots;
+
+        return pool.FirstOrDefault(snapshot => snapshot.IsDefault) ?? pool.FirstOrDefault();
+    }
+
+    private static SonarrSnapshot? ResolveSonarrSnapshot(ServarrRequestContext context, IReadOnlyCollection<SonarrSnapshot> snapshots)
+    {
+        if (snapshots.Count == 0)
+        {
+            return null;
+        }
+
+        List<SonarrSnapshot> matches = snapshots.Where(snapshot => snapshot.Matches(context)).ToList();
+        IReadOnlyCollection<SonarrSnapshot> pool = matches.Count > 0 ? matches : snapshots;
+
+        return pool.FirstOrDefault(snapshot => snapshot.IsDefault) ?? pool.FirstOrDefault();
     }
 
     private static ServarrProgressInfo? BuildMovieProgress(ServarrRequestContext context, RadarrSnapshot? snapshot)
@@ -265,7 +336,7 @@ public sealed class ServarrProgressService
 
         if (queueItems.Count > 0)
         {
-            return BuildQueueProgress(queueItems, snapshot.BaseUrl, movie, isMovie: true);
+            return BuildQueueProgress(queueItems, snapshot.BaseUrl, movie, isMovie: true, snapshot.InstanceName);
         }
 
         if (movie == null)
@@ -278,7 +349,8 @@ public sealed class ServarrProgressService
             monitored: movie.Value<bool?>("monitored") ?? false,
             isUnreleased: IsUnreleasedMedia(movie.Value<string>("status")),
             sizeOnDisk: movie.Value<long?>("sizeOnDisk") ?? 0,
-            openUrl: BuildServarrOpenUrl(snapshot.BaseUrl, GetTitleSlug(movie), isMovie: true));
+            openUrl: BuildServarrOpenUrl(snapshot.BaseUrl, GetTitleSlug(movie), isMovie: true),
+            instanceName: snapshot.InstanceName);
     }
 
     private static ServarrProgressInfo? BuildSeriesProgress(ServarrRequestContext context, SonarrSnapshot? snapshot)
@@ -300,7 +372,7 @@ public sealed class ServarrProgressService
 
         if (queueItems.Count > 0)
         {
-            return BuildQueueProgress(queueItems, snapshot.BaseUrl, series, isMovie: false);
+            return BuildQueueProgress(queueItems, snapshot.BaseUrl, series, isMovie: false, snapshot.InstanceName);
         }
 
         List<JObject> episodes = seriesId.HasValue && snapshot.EpisodesBySeriesId.TryGetValue(seriesId.Value, out List<JObject>? eps)
@@ -312,7 +384,13 @@ public sealed class ServarrProgressService
             bool monitored = series.Value<bool?>("monitored") ?? false;
             long sizeOnDisk = series.Value<long?>("sizeOnDisk") ?? 0;
             bool hasFile = sizeOnDisk > 0;
-            return BuildLibraryProgress(hasFile, monitored, isUnreleased: false, sizeOnDisk, BuildServarrOpenUrl(snapshot.BaseUrl, GetTitleSlug(series), isMovie: false));
+            return BuildLibraryProgress(
+                hasFile,
+                monitored,
+                isUnreleased: false,
+                sizeOnDisk,
+                BuildServarrOpenUrl(snapshot.BaseUrl, GetTitleSlug(series), isMovie: false),
+                snapshot.InstanceName);
         }
 
         bool anyFile = episodes.Any(e => e.Value<bool?>("hasFile") == true);
@@ -327,28 +405,33 @@ public sealed class ServarrProgressService
 
         if (allUnreleased && !anyFile)
         {
-            return BuildLibraryProgress(false, anyMonitored, true, 0, seriesOpenUrl);
+            return BuildLibraryProgress(false, anyMonitored, true, 0, seriesOpenUrl, snapshot.InstanceName);
         }
 
         if (allHaveFiles && allMonitored)
         {
-            return BuildLibraryProgress(true, true, false, totalSize, seriesOpenUrl);
+            return BuildLibraryProgress(true, true, false, totalSize, seriesOpenUrl, snapshot.InstanceName);
         }
 
         if (allHaveFiles)
         {
-            return BuildLibraryProgress(true, false, false, totalSize, seriesOpenUrl);
+            return BuildLibraryProgress(true, false, false, totalSize, seriesOpenUrl, snapshot.InstanceName);
         }
 
         if (!anyFile && anyMonitored)
         {
-            return BuildLibraryProgress(false, true, false, 0, seriesOpenUrl);
+            return BuildLibraryProgress(false, true, false, 0, seriesOpenUrl, snapshot.InstanceName);
         }
 
-        return BuildLibraryProgress(false, false, false, 0, seriesOpenUrl);
+        return BuildLibraryProgress(false, false, false, 0, seriesOpenUrl, snapshot.InstanceName);
     }
 
-    private static ServarrProgressInfo BuildQueueProgress(IReadOnlyCollection<JObject> queueItems, string baseUrl, JObject? media, bool isMovie)
+    private static ServarrProgressInfo BuildQueueProgress(
+        IReadOnlyCollection<JObject> queueItems,
+        string baseUrl,
+        JObject? media,
+        bool isMovie,
+        string instanceName)
     {
         double totalSize = queueItems.Sum(item => item.Value<double?>("size") ?? 0);
         double sizeLeft = queueItems.Sum(item => item.Value<double?>("sizeleft") ?? 0);
@@ -367,11 +450,18 @@ public sealed class ServarrProgressService
             DownloadedBytes = (long)downloaded,
             TotalBytes = (long)totalSize,
             IsActive = true,
-            OpenUrl = BuildServarrOpenUrl(baseUrl, titleSlug, isMovie)
+            OpenUrl = BuildServarrOpenUrl(baseUrl, titleSlug, isMovie),
+            InstanceName = instanceName
         };
     }
 
-    private static ServarrProgressInfo BuildLibraryProgress(bool hasFile, bool monitored, bool isUnreleased, long sizeOnDisk, string? openUrl = null)
+    private static ServarrProgressInfo BuildLibraryProgress(
+        bool hasFile,
+        bool monitored,
+        bool isUnreleased,
+        long sizeOnDisk,
+        string? openUrl = null,
+        string? instanceName = null)
     {
         if (isUnreleased)
         {
@@ -383,7 +473,8 @@ public sealed class ServarrProgressService
                 DownloadedBytes = 0,
                 TotalBytes = 0,
                 IsActive = false,
-                OpenUrl = openUrl
+                OpenUrl = openUrl,
+                InstanceName = instanceName ?? string.Empty
             };
         }
 
@@ -399,7 +490,8 @@ public sealed class ServarrProgressService
                 DownloadedBytes = sizeOnDisk,
                 TotalBytes = sizeOnDisk,
                 IsActive = downloadedActive,
-                OpenUrl = openUrl
+                OpenUrl = openUrl,
+                InstanceName = instanceName ?? string.Empty
             };
         }
 
@@ -413,7 +505,8 @@ public sealed class ServarrProgressService
                 DownloadedBytes = sizeOnDisk,
                 TotalBytes = sizeOnDisk,
                 IsActive = downloadedActive,
-                OpenUrl = openUrl
+                OpenUrl = openUrl,
+                InstanceName = instanceName ?? string.Empty
             };
         }
 
@@ -427,7 +520,8 @@ public sealed class ServarrProgressService
                 DownloadedBytes = 0,
                 TotalBytes = 0,
                 IsActive = false,
-                OpenUrl = openUrl
+                OpenUrl = openUrl,
+                InstanceName = instanceName ?? string.Empty
             };
         }
 
@@ -439,7 +533,8 @@ public sealed class ServarrProgressService
             DownloadedBytes = 0,
             TotalBytes = 0,
             IsActive = false,
-            OpenUrl = openUrl
+            OpenUrl = openUrl,
+            InstanceName = instanceName ?? string.Empty
         };
     }
 
@@ -590,19 +685,36 @@ public sealed class ServarrProgressService
         string Type,
         int TmdbId,
         int? ExternalServiceId,
-        HashSet<int> SeasonNumbers);
+        HashSet<int> SeasonNumbers,
+        bool Is4k);
 
     private sealed record RadarrSnapshot(
+        string InstanceName,
+        bool IsDefault,
+        bool Is4k,
         string BaseUrl,
         Dictionary<int, JObject> MoviesByTmdbId,
         Dictionary<int, List<JObject>> QueueByMovieId,
-        Dictionary<int, List<JObject>> QueueByTmdbId);
+        Dictionary<int, List<JObject>> QueueByTmdbId)
+    {
+        public bool Matches(ServarrRequestContext context) =>
+            MoviesByTmdbId.ContainsKey(context.TmdbId)
+            || QueueByTmdbId.ContainsKey(context.TmdbId)
+            || (context.ExternalServiceId.HasValue && QueueByMovieId.ContainsKey(context.ExternalServiceId.Value));
+    }
 
     private sealed record SonarrSnapshot(
+        string InstanceName,
+        bool IsDefault,
         string BaseUrl,
         Dictionary<int, JObject> SeriesByTmdbId,
         Dictionary<int, List<JObject>> EpisodesBySeriesId,
-        Dictionary<int, List<JObject>> QueueBySeriesId);
+        Dictionary<int, List<JObject>> QueueBySeriesId)
+    {
+        public bool Matches(ServarrRequestContext context) =>
+            SeriesByTmdbId.ContainsKey(context.TmdbId)
+            || (context.ExternalServiceId.HasValue && QueueBySeriesId.ContainsKey(context.ExternalServiceId.Value));
+    }
 
     private sealed class ServarrProgressInfo
     {
@@ -619,5 +731,7 @@ public sealed class ServarrProgressService
         public bool IsActive { get; set; }
 
         public string? OpenUrl { get; set; }
+
+        public string InstanceName { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
This PR extends SeerrFin’s existing Servarr integration from one Radarr and one Sonarr instance to multiple instances per type, without changing the core request flow.

The goal is not to redesign the plugin, but to let users register additional Radarr/Sonarr endpoints and have the plugin treat them the same way as the current single-instance setup.

  What changed

  - Added a multi-instance Servarr configuration model.
  - Kept legacy single-instance fields for backward compatibility.
  - Migrated existing Radarr/Sonarr settings into the new list-based structure automatically.
  - Reworked the admin configuration UI to allow adding multiple Radarr and Sonarr instances.
  - Added a + flow for creating additional instances.
  - Added per-instance defaults and a Radarr-only 4K flag.
  - Updated Requests progress handling to resolve the correct instance per request.
  - Updated open links in the Requests UI to use the correct Radarr/Sonarr instance.
  - Preserved the existing Seerr request flow and quality-profile behavior.

  Compatibility notes

  - Existing single-instance installs continue to work.
  - Legacy Radarr/Sonarr values are still supported and are migrated into the new structure.
  - Seerr remains a single instance; only Radarr and Sonarr were expanded.

  Testing

  Verified locally and in Jellyfin using a separate test manifest and fork release:

  - repository added successfully
  - plugin installed successfully
  - Jellyfin restart and setup successful
  - single-instance configs still work
  - multiple Radarr/Sonarr instances can be added and saved
  - Requests/Progress/Quality Profile data loads correctly
  - the correct target instance is used for the request flow

  Test release used

  - 1.6.5.2
  - separate test manifest repo: helitra/SeerrFin-test-manifest
  - test manifest URL:
      - https://raw.githubusercontent.com/helitra/SeerrFin-test-manifest/main/manifest.json
