### PR TITLE
fix: keep the monitored state when a season is partially downloaded

### DIFF
--- a/src/Jellyfin.Plugin.SeerrFin/Services/ServarrProgressService.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Services/ServarrProgressService.cs
@@ -345,7 +345,7 @@ public sealed class ServarrProgressService
             return BuildLibraryProgress(false, true, false, 0, seriesOpenUrl);
         }
 
-        return BuildLibraryProgress(false, false, false, 0, seriesOpenUrl);
+        return BuildLibraryProgress(false, anyMonitored, false, 0, seriesOpenUrl);
     }
 
     private static ServarrProgressInfo BuildQueueProgress(IReadOnlyCollection<JObject> queueItems, string baseUrl, JObject? media, bool isMovie)


### PR DESCRIPTION
Fixes #31.

### The problem

Any TV request whose season is **partially downloaded** — the normal state of a
currently airing show — is shown as `Missing (Unmonitored)` on the Requests tab,
even when every episode is monitored in Sonarr.

`ServarrProgressService.cs` decides the label with this chain (lines ~330–348):

```csharp
if (allUnreleased && !anyFile)      return ... // Unreleased
if (allHaveFiles && allMonitored)   return ... // Downloaded (Monitored)
if (allHaveFiles)                   return ... // Downloaded (Unmonitored)
if (!anyFile && anyMonitored)       return ... // Missing (Monitored)
return BuildLibraryProgress(false, false, ...); // Missing (Unmonitored)
```

There are branches for *nothing downloaded* and for *everything downloaded*, but
none for *some episodes downloaded*:

- `allHaveFiles` is false → branches 2 and 3 are skipped
- `!anyFile` is false → branch 4 is skipped, **even when every episode is
  monitored**

So it reaches the final `return`, which hardcodes `monitored: false`. The
label's second half is then simply untrue.

This is not about season scoping — `FilterEpisodesBySeasons` works correctly.
Verified below: restricting to the requested season changes the episode count
but not the outcome.

### The change

```diff
-        return BuildLibraryProgress(false, false, false, 0, seriesOpenUrl);
+        return BuildLibraryProgress(false, anyMonitored, false, 0, seriesOpenUrl);
```

`BuildLibraryProgress(hasFile: false, monitored: true, …)` already renders
`Missing (Monitored)`, so no new state is introduced and no other branch changes
behaviour — the earlier `!anyFile && anyMonitored` return covers the "nothing
downloaded yet" case identically.

### Verified against

| Request | Episodes in requested season | With a file | Monitored | Before | After |
|---|---|---|---|---|---|
| `Tomb Raider King` — s1 | 12 | 4 | 10 | `Missing (Unmonitored)` | `Missing (Monitored)` |
| `That Time I Got Reincarnated as a Slime` — s4 | 24 | 4 | 10 | `Missing (Unmonitored)` | `Missing (Monitored)` |

Numbers taken from `GET /api/v3/episode?seriesId=N`. In the second case the
season filter is demonstrably active — the requested season yields 24 episodes
where the whole series has 96 — and the label was unchanged, which is what rules
scoping out as the cause.

Environment: SeerrFin 1.6.6.0 · Jellyfin 10.11.11 · Sonarr 4.0.19.2979 ·
Jellyseerr 3.4.1.

Builds clean against `JellyfinVersion=10.11.11` on .NET 9 — 0 warnings, 0 errors.

### Possible follow-up (not in this PR)

A partially downloaded season could deserve its own state rather than sharing
`Missing`: the progress bar currently reads 0% while `totalSize` is already
known for the episodes that do have files, so it could show real progress.

Also worth knowing: Sonarr's series-level `statistics.episodeFileCount` counts
only **monitored** episodes — it reports 4/4 for the first case above while the
episode list reports 4 of 12. If that field is used anywhere the two numbers
will disagree in exactly this scenario.
