### PR TITLE
feat: Add option to use Seerr default quality profiles

### DIFF
--- a/src/Jellyfin.Plugin.SeerrFin/Configuration/Advanced/RequestModalSettings.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Configuration/Advanced/RequestModalSettings.cs
@@ -2,6 +2,8 @@ namespace Jellyfin.Plugin.SeerrFin.Configuration.Advanced;
 
 public class AdvancedRequestModalSettings
 {
+    public bool AllowQualityProfileSelection { get; set; } = true;
+
     public bool TvSeasonPickerEnabled { get; set; } = true;
 
     public bool IncludeSpecialsSeason { get; set; }

--- a/src/Jellyfin.Plugin.SeerrFin/Configuration/Advanced/SettingsHelper.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Configuration/Advanced/SettingsHelper.cs
@@ -212,6 +212,7 @@ public static class AdvancedSettingsHelper
             },
             requestModal = new
             {
+                allowQualityProfileSelection = advanced.RequestModal.AllowQualityProfileSelection,
                 tvSeasonPickerEnabled = advanced.RequestModal.TvSeasonPickerEnabled,
                 includeSpecialsSeason = advanced.RequestModal.IncludeSpecialsSeason,
                 requireExplicitSeasonSelection = advanced.RequestModal.RequireExplicitSeasonSelection,

--- a/src/Jellyfin.Plugin.SeerrFin/Configuration/config.html
+++ b/src/Jellyfin.Plugin.SeerrFin/Configuration/config.html
@@ -1405,8 +1405,15 @@
                             <div class="bst-card">
                         <div class="bst-toggle-row">
                             <div class="bst-toggle-copy">
+                                <label class="bst-toggle-label" for="advAllowQualityProfileSelection">Allow users to choose quality</label>
+                                <div class="bst-field-desc">When disabled, requests use the default Radarr or Sonarr profile configured in Seerr.</div>
+                            </div>
+                            <label class="bst-toggle"><input id="advAllowQualityProfileSelection" type="checkbox" checked /><span class="bst-toggle-slider"></span></label>
+                        </div>
+                        <div class="bst-toggle-row">
+                            <div class="bst-toggle-copy">
                                 <label class="bst-toggle-label" for="advTvSeasonPickerEnabled">TV season picker</label>
-                                <div class="bst-field-desc">Show a season picker before choosing a quality profile for TV.</div>
+                                <div class="bst-field-desc">Show a season picker before submitting a TV request.</div>
                             </div>
                             <label class="bst-toggle"><input id="advTvSeasonPickerEnabled" type="checkbox" checked /><span class="bst-toggle-slider"></span></label>
                         </div>
@@ -2344,6 +2351,7 @@
                         RefreshOnTabShow: true
                     },
                     RequestModal: {
+                        AllowQualityProfileSelection: true,
                         TvSeasonPickerEnabled: true,
                         IncludeSpecialsSeason: false,
                         RequireExplicitSeasonSelection: false,
@@ -2446,6 +2454,7 @@
                 document.querySelector('#advSplitPartiallyAvailableFilter').checked = r.SplitPartiallyAvailableFilter === true;
 
                 const m = advanced.RequestModal;
+                document.querySelector('#advAllowQualityProfileSelection').checked = m.AllowQualityProfileSelection !== false;
                 document.querySelector('#advTvSeasonPickerEnabled').checked = m.TvSeasonPickerEnabled !== false;
                 document.querySelector('#advIncludeSpecialsSeason').checked = m.IncludeSpecialsSeason === true;
                 document.querySelector('#advRequireExplicitSeasonSelection').checked = m.RequireExplicitSeasonSelection === true;
@@ -2518,6 +2527,7 @@
                         RefreshOnTabShow: document.querySelector('#advRequestsRefreshOnTabShow').checked
                     },
                     RequestModal: {
+                        AllowQualityProfileSelection: document.querySelector('#advAllowQualityProfileSelection').checked,
                         TvSeasonPickerEnabled: document.querySelector('#advTvSeasonPickerEnabled').checked,
                         IncludeSpecialsSeason: document.querySelector('#advIncludeSpecialsSeason').checked,
                         RequireExplicitSeasonSelection: document.querySelector('#advRequireExplicitSeasonSelection').checked,

--- a/src/Jellyfin.Plugin.SeerrFin/Controllers/SeerrFinController.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Controllers/SeerrFinController.cs
@@ -650,8 +650,12 @@ public class SeerrFinController : ControllerBase
             return Forbid();
         }
 
+        bool allowQualityProfileSelection = AdvancedSettingsHelper
+            .Resolve(SeerrFinPlugin.Instance.Configuration)
+            .RequestModal
+            .AllowQualityProfileSelection;
         (int statusCode, string body, string contentType) = await _requestService
-            .SubmitRequestAsync(username, payload, cancellationToken)
+            .SubmitRequestAsync(username, payload, allowQualityProfileSelection, cancellationToken)
             .ConfigureAwait(false);
 
         return new ContentResult

--- a/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-modal.js
+++ b/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-modal.js
@@ -56,6 +56,7 @@ window.seerrFinLog = window.seerrFinLog || {
             ? plugin._displaySettings.Advanced.requestModal
             : null;
         return {
+            allowQualityProfileSelection: readAdvancedBool(modal && modal.allowQualityProfileSelection, true),
             tvSeasonPickerEnabled: readAdvancedBool(modal && modal.tvSeasonPickerEnabled, true),
             includeSpecialsSeason: readAdvancedBool(modal && modal.includeSpecialsSeason, false),
             requireExplicitSeasonSelection: readAdvancedBool(modal && modal.requireExplicitSeasonSelection, false),
@@ -877,8 +878,9 @@ window.seerrFinLog = window.seerrFinLog || {
         });
     }
 
-    function renderQualityModalShell(is4k) {
-        const title = is4k ? 'Choose 4K quality profile' : 'Choose quality profile';
+    function renderQualityModalShell(is4k, useSeerrDefaults) {
+        const title = useSeerrDefaults ? 'Request' : (is4k ? 'Choose 4K quality profile' : 'Choose quality profile');
+        const loadingText = useSeerrDefaults ? 'Submitting request…' : 'Loading profiles…';
         return `
             <div class="bst-quality-wrapper">
                 <div class="bst-quality-backdrop"></div>
@@ -887,7 +889,7 @@ window.seerrFinLog = window.seerrFinLog || {
                         <h3 id="bst-quality-title">${title}</h3>
                         <button type="button" class="bst-quality-close" aria-label="Close">${CLOSE_ICON}</button>
                     </div>
-                    <div class="bst-quality-list"><div class="bst-quality-loading">Loading profiles…</div></div>
+                    <div class="bst-quality-list"><div class="bst-quality-loading">${loadingText}</div></div>
                 </div>
             </div>`;
     }
@@ -926,10 +928,11 @@ window.seerrFinLog = window.seerrFinLog || {
         }
 
         is4k = !!is4k;
+        const useSeerrDefaults = getRequestModalAdvanced().allowQualityProfileSelection === false;
 
         // Show shell so the click feels instant (fill profiles when the api returns)
         closeQualityModal();
-        document.body.insertAdjacentHTML('beforeend', renderQualityModalShell(is4k));
+        document.body.insertAdjacentHTML('beforeend', renderQualityModalShell(is4k, useSeerrDefaults));
         activeQualityRoot = document.body.lastElementChild;
 
         const list = activeQualityRoot.querySelector('.bst-quality-list');
@@ -949,6 +952,14 @@ window.seerrFinLog = window.seerrFinLog || {
                 return;
             }
             list.innerHTML = `<div class="bst-quality-empty">${escapeHtml(message || 'Request failed')}</div>`;
+        }
+
+        if (useSeerrDefaults) {
+            submitRequest(mediaId, mediaType, {
+                is4k: is4k,
+                seasons: selectedSeasons
+            }, finishRequest, failRequest).catch(function () {});
+            return;
         }
 
         ApiClient.ajax({

--- a/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.js
+++ b/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.js
@@ -1291,6 +1291,7 @@ if (typeof window.seerrFinPlugin === 'undefined') {
                     refreshOnTabShow: self.readAdvancedBool(requests.refreshOnTabShow ?? requests.RefreshOnTabShow, true)
                 },
                 requestModal: {
+                    allowQualityProfileSelection: self.readAdvancedBool(requestModal.allowQualityProfileSelection ?? requestModal.AllowQualityProfileSelection, true),
                     tvSeasonPickerEnabled: self.readAdvancedBool(requestModal.tvSeasonPickerEnabled ?? requestModal.TvSeasonPickerEnabled, true),
                     includeSpecialsSeason: self.readAdvancedBool(requestModal.includeSpecialsSeason ?? requestModal.IncludeSpecialsSeason, false),
                     requireExplicitSeasonSelection: self.readAdvancedBool(requestModal.requireExplicitSeasonSelection ?? requestModal.RequireExplicitSeasonSelection, false),

--- a/src/Jellyfin.Plugin.SeerrFin/Services/JellyseerrRequestService.cs
+++ b/src/Jellyfin.Plugin.SeerrFin/Services/JellyseerrRequestService.cs
@@ -68,7 +68,14 @@ public class JellyseerrRequestService
         };
     }
 
-    public async Task<(int StatusCode, string Body, string ContentType)> SubmitRequestAsync(string username, DiscoverRequestPayload payload, CancellationToken cancellationToken)
+    public Task<(int StatusCode, string Body, string ContentType)> SubmitRequestAsync(string username, DiscoverRequestPayload payload, CancellationToken cancellationToken) =>
+        SubmitRequestAsync(username, payload, allowQualityProfileSelection: true, cancellationToken: cancellationToken);
+
+    public async Task<(int StatusCode, string Body, string ContentType)> SubmitRequestAsync(
+        string username,
+        DiscoverRequestPayload payload,
+        bool allowQualityProfileSelection,
+        CancellationToken cancellationToken)
     {
         PluginConfiguration config = SeerrFinPlugin.Instance.Configuration;
         if (string.IsNullOrWhiteSpace(config.JellyseerrUrl) || string.IsNullOrWhiteSpace(config.JellyseerrApiKey))
@@ -104,8 +111,8 @@ public class JellyseerrRequestService
                 : "all";
         }
 
-        // Only Advanced Requests can override Seerr defaults
-        if (HasRequestAdvanced(permissions))
+        // Only Advanced Requests can override Seerr defaults, and admins can disable profile selection for the request modal.
+        if (allowQualityProfileSelection && HasRequestAdvanced(permissions))
         {
             if (payload.ServerId != null)
             {


### PR DESCRIPTION
## Summary

- Add an `Allow users to choose quality` toggle under `Advanced → Request modal`.
- Keep the toggle enabled by default so existing installations retain their current behavior.
- When disabled, movie and TV requests skip the profile picker and use the default Radarr or Sonarr profile configured in Seerr.
- Enforce the setting in the request controller so submitted server/profile/root-folder overrides are ignored when profile selection is disabled.
- Keep the Letterboxd bulk quality workflow independent because it has its own advanced quality settings.

## How I tested

- Ran `dotnet build SeerrFin.sln -c Release` with .NET 9: 0 warnings and 0 errors.
- Ran `node --check` against every injected JavaScript file and the configuration page script.
- Used a local browser fixture with the real injected modal script and verified:
  - Disabled: the modal displays `Submitting request…` and sends a POST containing only media type, media ID, and 4K state, without `ServerId`, `ProfileId`, or `RootFolder`.
  - Enabled: the existing quality picker opens and loads `request-options/movie`.
  - The new toggle is visible and checked by default under `Advanced → Request modal`.
- Confirmed the new setting and frontend payload are embedded in the Release DLL.

## Environment

- Target: Jellyfin 10.11.x / ABI 10.11.0.0
- Build SDK: .NET 9
- Browser validation: local Chromium fixture on macOS

## Pending real-instance validation

This PR is intentionally opened as a draft until the behavior has been verified on a real Jellyfin + Seerr installation. The server test should cover both a user with Advanced Requests permission and a standard request-only user, with the toggle enabled and disabled.

## AI assistance

OpenAI Codex (GPT-5) was used to inspect the request flow, implement the focused setting, run the .NET/JavaScript checks, and exercise the local browser fixture. The change was kept separate from the localization PR to follow the repository's one-feature-per-PR rule.