### PR TITLE
fix: Stop repeated searches after empty results

### DIFF
--- a/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.js
+++ b/src/Jellyfin.Plugin.SeerrFin/Inject/seerrfin-tabs.js
@@ -3086,6 +3086,8 @@ if (typeof window.seerrFinPlugin === 'undefined') {
             if (!searchPage || !input || !query || !self.isSearchSettingEnabled()) {
                 self.removeSearchSection();
                 self._lastSearchQuery = null;
+                self._lastSearchItems = null;
+                self._activeSearchToken = null;
                 return;
             }
 
@@ -3151,11 +3153,17 @@ if (typeof window.seerrFinPlugin === 'undefined') {
                 return;
             }
 
-            if (self._lastSearchQuery === query && document.querySelector('.seerrfin-search-section')) {
+            if (self._lastSearchQuery === query) {
+                if (!searchPage.querySelector('.seerrfin-search-section') &&
+                    Array.isArray(self._lastSearchItems) &&
+                    self._lastSearchItems.length) {
+                    self.renderSearchSection(searchPage, query, self._lastSearchItems);
+                }
                 return;
             }
 
             self._lastSearchQuery = query;
+            self._lastSearchItems = null;
             const token = Date.now().toString(36) + Math.random().toString(36).slice(2);
             self._activeSearchToken = token;
 
@@ -3178,9 +3186,11 @@ if (typeof window.seerrFinPlugin === 'undefined') {
                     return;
                 }
 
+                self._lastSearchItems = result.items;
                 self.renderSearchSection(currentPage, query, result.items);
             }).catch(function (err) {
                 if (self._activeSearchToken === token) {
+                    self._lastSearchItems = [];
                     log.warn('search failed for "' + query + '"', err);
                     self.removeSearchSection();
                 }


### PR DESCRIPTION
## Summary

- Stop the search-page MutationObserver from repeatedly calling `display-settings` and `search` when Seerr returns no results or the search request fails.
- Cache completed search results by query so DOM mutations do not trigger another network request for the same input.
- Reinsert cached non-empty results if Jellyfin replaces the search results container.
- Reset the cached search state when the query is cleared, changed, or the integration is disabled.

## Root cause

The search integration removed its temporary Seerr section after an empty result or a failed request. The body MutationObserver saw that removal, scheduled the same search again, and repeated the cycle indefinitely because the deduplication guard only worked while a `.seerrfin-search-section` element existed.

## How I tested

- Ran `dotnet build SeerrFin.sln -c Release` with .NET 9: 0 warnings and 0 errors.
- Ran `node --check` against every injected JavaScript file.
- Used a local Chromium fixture with the real `seerrfin-tabs.js`, a visible Jellyfin-style search page, and request counters.
- Verified for three seconds after each scenario:
  - Empty Seerr result: exactly one `display-settings` call and one `search` call.
  - Rejected Seerr search: exactly one `display-settings` call and one `search` call.

## Environment

- Target: Jellyfin 10.11.x / ABI 10.11.0.0
- Build SDK: .NET 9
- Browser validation: local Chromium fixture on macOS

## Pending real-instance validation

This PR is intentionally opened as a draft until the fix has been verified on the Jellyfin instance that reported the repeated requests.

## AI assistance

OpenAI Codex (GPT-5) was used to trace the observer/search interaction, implement the focused state guard, run the build and syntax checks, and reproduce both empty-result and failed-request cases in a local browser fixture.